### PR TITLE
Add option to automatically connect to system JACK ports, if they are available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ dependencies = [
  "clack-extensions",
  "clack-host",
  "clap",
+ "const_format",
  "jack",
  "linefeed",
 ]
@@ -190,6 +191,26 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "const_format"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -632,6 +653,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ clack-host = {git = "https://github.com/prokopyl/clack.git", rev = "5deaa1b"}
 clack-extensions = {git = "https://github.com/prokopyl/clack.git", rev = "5deaa1b", features = ["clack-host", "params"]}
 jack = "0.13.0"
 linefeed = "0.6.0"
+const_format = "0.2.33"

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,8 +3,13 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[command(author, version)]
 pub(crate) struct ClackAudioHostArgs {
+    /// Path to a CLAP plugin
     pub path: String,
 
     #[arg(short, long)]
     pub verbose: bool,
+    
+    #[arg(short, long, default_value="false")]
+    /// Attempt to connect the plugin to system JACK I/O
+    pub use_system_io: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn main() {
     let args = ClackAudioHostArgs::parse();
 
     // Set up the JACK client
-    let (client, _status) = Client::new("clack_audio_host", jack::ClientOptions::NO_START_SERVER)
+    let (client, _status) = Client::new(HOST_NAME, jack::ClientOptions::NO_START_SERVER)
         .expect("Unable to create JACK client!");
     let mut port_out_l = client
         .register_port(PLUGIN_AUDIO_OUT_L_PORT, AudioOut::default())

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use clap::Parser;
 use jack::{contrib::ClosureProcessHandler, AudioIn, AudioOut, Client, Control, MidiIn};
 use linefeed::{Interface, ReadResult};
 use std::sync::{Arc, Mutex};
+use const_format::formatcp;
 
 const HOST_NAME: &str = env!("CARGO_PKG_NAME");
 const HOST_VENDOR: &str = env!("CARGO_PKG_AUTHORS");
@@ -23,6 +24,28 @@ const HOST_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const PLUGIN_CONFIG_MIN_FRAMES: u32 = 1;
 const PLUGIN_CONFIG_MAX_FRAMES: u32 = 128;
+
+const PLUGIN_AUDIO_OUT_L_PORT: &str = "out_l";
+const PLUGIN_AUDIO_OUT_R_PORT: &str = "out_r";
+const PLUGIN_AUDIO_IN_L_PORT: &str = "in_l";
+const PLUGIN_AUDIO_IN_R_PORT: &str = "in_r";
+const PLUGIN_MIDI_IN_PORT: &str = "midi_in";
+
+const PLUGIN_AUDIO_OUT_L_PORT_NAME: &str = formatcp!("{HOST_NAME}:{PLUGIN_AUDIO_OUT_L_PORT}");
+const PLUGIN_AUDIO_OUT_R_PORT_NAME: &str = formatcp!("{HOST_NAME}:{PLUGIN_AUDIO_OUT_R_PORT}");
+const PLUGIN_AUDIO_IN_L_PORT_NAME: &str = formatcp!("{HOST_NAME}:{PLUGIN_AUDIO_IN_L_PORT}");
+const PLUGIN_AUDIO_IN_R_PORT_NAME: &str = formatcp!("{HOST_NAME}:{PLUGIN_AUDIO_IN_R_PORT}");
+const PLUGIN_MIDI_IN_PORT_NAME: &str = formatcp!("{HOST_NAME}:{PLUGIN_MIDI_IN_PORT}");
+
+const SYSTEM_AUDIO_CLIENT_NAME: &str = "system";
+const SYSTEM_MIDI_CLIENT_NAME: &str = "system_midi";
+
+const SYSTEM_AUDIO_CAPTURE_L_PORT_NAME: &str = formatcp!("{SYSTEM_AUDIO_CLIENT_NAME}:capture_1");
+const SYSTEM_AUDIO_CAPTURE_R_PORT_NAME: &str = formatcp!("{SYSTEM_AUDIO_CLIENT_NAME}:capture_2");
+const SYSTEM_MIDI_CAPTURE_PORT_NAME: &str = formatcp!("{SYSTEM_MIDI_CLIENT_NAME}:capture_1");
+const SYSTEM_AUDIO_PLAYBACK_L_PORT_NAME: &str = formatcp!("{SYSTEM_AUDIO_CLIENT_NAME}:playback_1");
+const SYSTEM_AUDIO_PLAYBACK_R_PORT_NAME: &str = formatcp!("{SYSTEM_AUDIO_CLIENT_NAME}:playback_2");
+const SYSTEM_MIDI_PLAYBACK_PORT_NAME: &str = formatcp!("{SYSTEM_MIDI_CLIENT_NAME}:playback_1");
 
 struct ClackAudioHostShared;
 
@@ -58,19 +81,19 @@ fn main() {
     let (client, _status) = Client::new("clack_audio_host", jack::ClientOptions::NO_START_SERVER)
         .expect("Unable to create JACK client!");
     let mut port_out_l = client
-        .register_port("out_l", AudioOut::default())
+        .register_port(PLUGIN_AUDIO_OUT_L_PORT, AudioOut::default())
         .expect("Unable to create left output port!");
     let mut port_out_r = client
-        .register_port("out_r", AudioOut::default())
+        .register_port(PLUGIN_AUDIO_OUT_R_PORT, AudioOut::default())
         .expect("Unable to create right output port!");
     let port_in_l = client
-        .register_port("in_l", AudioIn::default())
+        .register_port(PLUGIN_AUDIO_IN_L_PORT, AudioIn::default())
         .expect("Unable to create left audio in port!");
     let port_in_r = client
-        .register_port("in_r", AudioIn::default())
+        .register_port(PLUGIN_AUDIO_IN_R_PORT, AudioIn::default())
         .expect("Unable to create right audio in port!");
     let midi_in = client
-        .register_port("midi_in", MidiIn::default())
+        .register_port(PLUGIN_MIDI_IN_PORT, MidiIn::default())
         .expect("Unable to create MIDI in port!");
     client
         .set_buffer_size(PLUGIN_CONFIG_MAX_FRAMES)
@@ -226,9 +249,43 @@ fn main() {
     });
 
     // Start the JACK client
-    let _active_client = client
+    let active_client = client
         .activate_async((), process_handler)
         .expect("Unable to activate client");
+
+    // Attempt to connect to system I/O, if requested
+    if args.use_system_io {
+        if let Err(e) = active_client.as_client().connect_ports_by_name(SYSTEM_AUDIO_CAPTURE_L_PORT_NAME, PLUGIN_AUDIO_IN_L_PORT_NAME) {
+            eprintln!("Unable to connect to system audio capture (left).");
+            if args.verbose {
+                eprintln!("Error: {e}");
+            }
+        }
+        if let Err(e) = active_client.as_client().connect_ports_by_name(SYSTEM_AUDIO_CAPTURE_R_PORT_NAME, PLUGIN_AUDIO_IN_R_PORT_NAME) {
+            eprintln!("Unable to connect to system audio capture (right).");
+            if args.verbose {
+                eprintln!("Error: {e}");
+            }
+        }
+        if let Err(e) = active_client.as_client().connect_ports_by_name(PLUGIN_AUDIO_OUT_L_PORT_NAME, SYSTEM_AUDIO_PLAYBACK_L_PORT_NAME) {
+            eprintln!("Unable to connect to system audio playback (left).");
+            if args.verbose {
+                eprintln!("Error: {e}");
+            }
+        }
+        if let Err(e) = active_client.as_client().connect_ports_by_name(PLUGIN_AUDIO_OUT_R_PORT_NAME, SYSTEM_AUDIO_PLAYBACK_R_PORT_NAME) {
+            eprintln!("Unable to connect to system audio playback (right).");
+            if args.verbose {
+                eprintln!("Error: {e}");
+            }
+        }
+        if let Err(e) = active_client.as_client().connect_ports_by_name(SYSTEM_MIDI_CAPTURE_PORT_NAME, PLUGIN_MIDI_IN_PORT_NAME) {
+            eprintln!("Unable to connect to system MIDI capture.");
+            if args.verbose {
+                eprintln!("Error: {e}");
+            }
+        }
+    }
 
     // Set up the REPL interface
     let interface = Interface::new(HOST_NAME).expect("Unable to create interface!");


### PR DESCRIPTION
This PR adds a new command line option to connect to the system JACK ports used by `qjackctl`. 

Closes #2 